### PR TITLE
review/2020-06-19

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,18 +21,39 @@ In adition to the envelope-spec, there are some scuttlebutt-specific specificati
 
 box1 took feedIds from the `content.recps` field and directly used these for encryption.
 
-In envelope, we instead take "ids" from `content.recps`, and map each to a pair`{ key, key_type }` where":
+In envelope, we instead take "ids" from `content.recps`, and map each to a pair `{ key, scheme }` where":
 - `key` is the shared key which we're going to a `key_slot`, and 
-- `key_type` is the "key management schema" which that key is employing
+- `scheme` is the "key management scheme" which that key is employing
 
 Type of id            | How `key` is found                                 | `scheme`
 ----------------------|----------------------------------------------------|-----------------------------------------
 private group id      | [a key-store](./group/group-id/README.md)          | "envelope-large-symmetric-group"
 classic feedId        | [diff-hellman styles](./direct-messages/README.md) | "envelope-id-based-dm-converted-ed25519"
-published private key | TODO                                               | "envelope-signed-dh-key-curve25519" ??
+published private key | TODO                                               | ???
 
-see `key-schemes.json` for the canonical list of accepted
+see `key-schemes.json` for the canonical list of accepted schema labels
 
+### recipient restrictions
+
+We talk about `key_slots` or recipients / `recps` a little interchangeably.
+Let's assume `recps` are mapped to `key_slots` preserving their order.
+
+:warning: The following restrictions must be followed :
+
+1. there are max 16 slots on a message
+2. if there is a group key
+    - a) there is only 1 group key in the slot
+    - b) the group key is in the first slot
+3. we disallow you from making a shared DM key with yourself
+
+More detail:
+- (1) means all implementations know to look 16 slots deep when trying to unbox the msg_key
+- (2.a) provides a guarentee that infomation is not leaked across groups, in particular tangle info would leak info about group memember as these ids are not cloaked in this version
+- (2.a + 2.b) means we that we only need to try group keys in the first slot. If that fails, we can try DM keys on slots 1-16. (nice and fast!)
+- (3) is a tight restriction which we think will help people write better apps
+    - it's a step towards forward security
+    - if you want to send to self, it encourages people to mint a group, which is a better practice when moving to support multi-device identities
+    - _we may relax this restriction when we have more experience_
 
 ## group management
 

--- a/index.js
+++ b/index.js
@@ -1,9 +1,12 @@
 module.exports = {
+  constants: {
+    directMessages: require('./direct-messages/constants.json')
+  },
   schema: {
     group: {
       init: require('./group/init/schema.json'),
       addMember: require('./group/add-member/schema.json')
     }
   },
-  keySchemes: require('./key-schemes.json')
+  keySchemes: require('./key-schemes.json').scheme
 }

--- a/vectors/direct-message-key1.json
+++ b/vectors/direct-message-key1.json
@@ -1,14 +1,14 @@
 {
   "type": "direct_message_shared_key",
-  "description": "calculate a shared DM key for another feedID",
+  "description": "calculate a shared DM key for another feedID. Note all inputs here are TFK encoded!",
   "input": {
-    "my_dh_secret": "oHz0nhFr8jeMDGboBB0McRsdTJJwSpfbOLcZHEsyeWc=",
-    "my_dh_public": "yC0PdAXkQ7Rn7ZiWvxLYh4o87JVEUElYse/4Cb4vxA4=",
-    "my_feed_tfk": "AAB0XWAxwFnBlTaIUuKVwtXLAsC8Hhh2ZhKPn44+eLuogA==",
-    "your_dh_public": "8419fvlDL7TJ/HA/T30q3rR/29kol/Q3HRWiYiSSVBA=",
-    "your_feed_tfk": "AADmNimSs3wcQ6L8+dwRB9mi3icNRRSWW3nQWS33Oki2OQ=="
+    "my_dh_secret": "AwCYUX45TyzMINj9mWyv/bZZqJ7KIIiB8VWc4m9Dyugqcw==",
+    "my_dh_public": "AwBrvX7hcWj+9HqQeZl0q+1O2StPVqvC1nz10eFwDvkZdw==",
+    "my_feed_id": "AADx3s2olg3gsJKDyzPcsKJCP09ark9UTjt+VuPLJPxZKg==",
+    "your_dh_public": "AwDdK8/CghFxYK/rP0JvKSgnlQFXBVJ6HYSYO4pHnxiFJw==",
+    "your_feed_id": "AADl/UwPnPSJXHgsDtEA0a+ShBCtcEF6FYHTFwm+VCW7mg=="
   },
   "output": {
-    "shared_key": "D9uHQqHLiPRTzV+TLa4dRUDZtfvUCwzVTGiOnzJCaXI="
+    "shared_key": "GxtuzHWe9egLij381oZ5VGNHtkmLrBeo57SC+mrcfMc="
   }
 }

--- a/vectors/direct-message-key1.json
+++ b/vectors/direct-message-key1.json
@@ -2,13 +2,13 @@
   "type": "direct_message_shared_key",
   "description": "calculate a shared DM key for another feedID. Note all inputs here are TFK encoded!",
   "input": {
-    "my_dh_secret": "AwCYUX45TyzMINj9mWyv/bZZqJ7KIIiB8VWc4m9Dyugqcw==",
-    "my_dh_public": "AwBrvX7hcWj+9HqQeZl0q+1O2StPVqvC1nz10eFwDvkZdw==",
-    "my_feed_id": "AADx3s2olg3gsJKDyzPcsKJCP09ark9UTjt+VuPLJPxZKg==",
-    "your_dh_public": "AwDdK8/CghFxYK/rP0JvKSgnlQFXBVJ6HYSYO4pHnxiFJw==",
-    "your_feed_id": "AADl/UwPnPSJXHgsDtEA0a+ShBCtcEF6FYHTFwm+VCW7mg=="
+    "my_dh_secret": "AwAAVBWosdJiUxa5F8b80q9zuDEKpOIZtPC8TUvAg7rKWA==",
+    "my_dh_public": "AwCgOagkeHCncXEVBdh1VJvD9MZHkwPx0zW8SF8V4b3BSw==",
+    "my_feed_id": "AAAUZ8SPimu5pvsd1V2gTnRAOFNaYYT57gUXsA+GxVXHMw==",
+    "your_dh_public": "AwANNqWZhzlZAfoeNJ2U/H525k8SP4zlvUU7a6SbkkxmZw==",
+    "your_feed_id": "AAA9ZhEGPhMmVd2y1YhnKh7r+RN4fI0pElnblvIgX7rQcg=="
   },
   "output": {
-    "shared_key": "GxtuzHWe9egLij381oZ5VGNHtkmLrBeo57SC+mrcfMc="
+    "shared_key": "DSf3Ac/sy5xLoulfxdpUwNlYPctJoCB7MiJksZsOn+U="
   }
 }

--- a/vectors/group-id1.json
+++ b/vectors/group-id1.json
@@ -2,22 +2,22 @@
   "type": "group_id",
   "description": "determine the group_id (remember group_id is derived from read_key of init msg)",
   "input": {
-    "group_key": "l9Ir+OgqPXBqmx+sn4bJou0wVM6g3vY7yadlVGDPMfE=",
+    "group_key": "TEZX9k0Rb+RDmcJ3qsn6ezNJuXogKsg30wM+7eQeKg0=",
     "group_init_msg": {
-      "key": "%H9M4kvM7RB1edUNRSME63uTs9a1rvx3D6S2tZXYQpok=.sha256",
+      "key": "%tvqtJASIMYGGboo/MWTPElsSx0iARbFiEnlledQC8EY=.sha256",
       "value": {
-        "previous": "%43aVczE5rQ6J6jAwsT/RoaGR+1ZA/aZENGH5OK4/5EY=.sha256",
+        "previous": "%iK1LJXnjY9aIWGkdgzsEYMPmYMkRqR1PT0ExFZSHzqY=.sha256",
         "sequence": 2,
-        "author": "@NgjdGBIClGSiwMugG/P1SSCZI7qEEWxAsy38BGuGF80=.ed25519",
-        "timestamp": 1592533020879,
+        "author": "@T9bytuo/+Kq8JcVhWmb5Fe4ErijGOt6WKBAoCKPcaO4=.ed25519",
+        "timestamp": 1592534932584,
         "hash": "sha256",
-        "content": "i6BX8AlcnmZi22vUhn0JxZCqOvS4b1D4Urxf2k4Yndi67j9ixMchhr9TrbpjBRyiOKvcqiBcq5ZVVMD98X/3T9g+7A6GD4cWkT03o4vosI4VW6wLh1CIokuyIyLewdFxBpApnFfaCU+tluHkhmiX6Uw48SGU2biiqSUBWVKsjZ0ARG74uomsBzs3zS9ftEH4ldTq+30/EA==.box2",
-        "signature": "XDMNhOicV+1pzORU8wBN6ktT6jn8PjurElTHbAEgrVb2+C560XctlE5xI47/T2SYOxjXUdoxMBHuK7PvtIV+Bw==.sig.ed25519"
+        "content": "7Zmi3ZtJa8rGmOMCMC6KuJ7sTlad7gog9YqDBAJVrZ0vPhxhoav8aCdIz71oGn4avEdOW6gTuLbPdn6Cv3aLymtFYqp+wiyScADsV4CmprVrW8I+XmslbrmDVBbPKR7UZ+xdP4WuW5JvWFUi2TTuAaUGwSMESQjbOpCXC/B8DP9Nhc+WcbotvKCVJOth9JgyPFfiPUbPzg==.box2",
+        "signature": "PRtXKVYqsf3a19ymZzUQXtQC+rUck9h/r1tH2BImaZnZ8mMKzc3qh8LTnrWPyeadcYMX2wVt4XtxIxkkhMciDA==.sig.ed25519"
       },
-      "timestamp": 1592533020880
+      "timestamp": 1592534932584.001
     }
   },
   "output": {
-    "group_id": "%CR7qdDLVr1abNE7ZxzNJPbuaMMFVa398mzrUPCO7/0M=.cloaked"
+    "group_id": "%6kFEq9AaVS/uhnKGARmPAIQdXcGkex8f1l//UFGZtSg=.cloaked"
   }
 }

--- a/vectors/group-id1.json
+++ b/vectors/group-id1.json
@@ -2,22 +2,22 @@
   "type": "group_id",
   "description": "determine the group_id (remember group_id is derived from read_key of init msg)",
   "input": {
-    "group_key": "KIAI3i6HrULIRS9C6Bo6tFkY0c5Sa1MlNOwkbRS/wtU=",
+    "group_key": "l9Ir+OgqPXBqmx+sn4bJou0wVM6g3vY7yadlVGDPMfE=",
     "group_init_msg": {
-      "key": "%B3SSeKnXIJuJCFVahYwiRSuKhwMd2dkOxEZqWDa9cSY=.sha256",
+      "key": "%H9M4kvM7RB1edUNRSME63uTs9a1rvx3D6S2tZXYQpok=.sha256",
       "value": {
-        "previous": "%dVSVm9ganErgKhFb11i1ehGhxF4sS6ZG5nUAXhki9F8=.sha256",
+        "previous": "%43aVczE5rQ6J6jAwsT/RoaGR+1ZA/aZENGH5OK4/5EY=.sha256",
         "sequence": 2,
-        "author": "@PtNht64FMww66fLD5U85GQKS5jxeKLvgaSBH2UC5mgU=.ed25519",
-        "timestamp": 1583365701788,
+        "author": "@NgjdGBIClGSiwMugG/P1SSCZI7qEEWxAsy38BGuGF80=.ed25519",
+        "timestamp": 1592533020879,
         "hash": "sha256",
-        "content": "G/G8hEAqh4bfm5le4YADCD6VpFu9yNiVNca+CobP+ftcySbW72dGVkkBYPA1AvzU+CaWcnwMh5qimnEz0PV6386QXUbDsmZlCd3x9GwHxgjCQGMLgEWfwg2zgHxYes7LRjMYcO7ADoqE8H5xpEnwxG3EUkgO5NnY+2/96tMzmq+DFJe6Zwze14V1nkMUGsnhTIgfElRkukOCEn4IXP3xKYBQXIddkLpyRvXvONVEHNnUjvZeaQ==.box2",
-        "signature": "l4CgKuB/A6kRgVc7mQSbwE+bQi3JWkD3WTj33EDwbVrEG5XXP+niJjOtVOHjmYKb2E+ebwcpvaBuB0DvI0qACQ==.sig.ed25519"
+        "content": "i6BX8AlcnmZi22vUhn0JxZCqOvS4b1D4Urxf2k4Yndi67j9ixMchhr9TrbpjBRyiOKvcqiBcq5ZVVMD98X/3T9g+7A6GD4cWkT03o4vosI4VW6wLh1CIokuyIyLewdFxBpApnFfaCU+tluHkhmiX6Uw48SGU2biiqSUBWVKsjZ0ARG74uomsBzs3zS9ftEH4ldTq+30/EA==.box2",
+        "signature": "XDMNhOicV+1pzORU8wBN6ktT6jn8PjurElTHbAEgrVb2+C560XctlE5xI47/T2SYOxjXUdoxMBHuK7PvtIV+Bw==.sig.ed25519"
       },
-      "timestamp": 1583365701789
+      "timestamp": 1592533020880
     }
   },
   "output": {
-    "group_id": "%/D7g6zyMWOJBQSkpZ7y1KpiBOMy/WQAj6Gd/NTIFres=.cloaked"
+    "group_id": "%CR7qdDLVr1abNE7ZxzNJPbuaMMFVa398mzrUPCO7/0M=.cloaked"
   }
 }

--- a/vectors/unbox1.json
+++ b/vectors/unbox1.json
@@ -4,26 +4,26 @@
   "input": {
     "msgs": [
       {
-        "key": "%ag+ImD4ezzbvjpblSTXnys3TQ4e5KFWW7pidvWqTQA0=.sha256",
+        "key": "%T5Q4w2/guQORn5Z0OBW+DVErq3YJkh21K9oOBCvwNrs=.sha256",
         "value": {
           "previous": null,
           "sequence": 1,
-          "author": "@b6jfpNg/RGhoc5IfHOLW6kPRmvst/xHPJWlC//4ZMXw=.ed25519",
-          "timestamp": 1583367070841,
+          "author": "@GDCXk8L74o7RF77JEuhV58EySUInU2oL9X28Ud9fYgA=.ed25519",
+          "timestamp": 1592533020780,
           "hash": "sha256",
-          "content": "QIWBINsKCQMx+AKKgxWPd6DkY9Og/YAVo7Y5MtYRUURqcPxNsMTw5yMrRd4gixkrGhQTqiPmDHBqkLksjA9hxF03nhq8PIOB2kTTIWcD9b7kZeFdF/OxuFBot4bRG/mwdnjR+pqHMC7DMv3Reaa4dNm6amW4yhr0EfO4Qr/dyhmUvBhywHaKDCgldoy3zZK8bXmlUpM3hSPYpEW6GsS06kZI8pKG/PPpSCTV7z5NaF6Cio5m/yH2SJCZRZD4embduw==.box2",
-          "signature": "xkh+41rhw8WUi8WXgYGu2Qur/roeuzbwX7N6x84XzQOt4dr8R1nV3Svkwq8q3Ai73RUgCD2V1hXqHSqmHqNoDg==.sig.ed25519"
+          "content": "4HViSb9O1mA4dSgoQPgUCsMvy1Br737ylOp83czpPo5kvmZeJg5dp04PTLfw838JS7APGhCcCBefq4iCl56cfuzvDZT8Lsihof/Yl+yVJM6mzf95Hj381oV7B7XWX8eqPYJ4PcB2AU7SHmUkcLNi/NXH/Pxtn18oYrALKsC15BRJNdrwRTK7OZsL1smOaemRr69nKHIab4RauwKFT2S9+AtJa/9j/ixG8ezkqB/iTmMmo4lbsT+1w5tb6rGU3BUOKA==.box2",
+          "signature": "Z7qRTEpyrTAidBzpxGa1h5gFE9bU+FZmezbQBcSPRy/YG1dkHejIZTwbp8mNgksG/ZQ0seKMFzCKbtJxqaCeDA==.sig.ed25519"
         },
-        "timestamp": 1583367070842
+        "timestamp": 1592533020780.001
       }
     ],
     "trial_keys": [
       {
-        "key": "d4s+DNsTunVpDyPTLL5OIx5/T2w0+wqIh8nK1YXFF1Q=",
+        "key": "8daH87AuneYvmZ5OANtkpugscaLO3QpQ8JX+1xpRKaU=",
         "scheme": "envelope-large-symmetric-group"
       },
       {
-        "key": "6ZXAUXgmqKEBysJbUSlz8W0LaOEXmdIpITsmkX4I1qY=",
+        "key": "oaBppadDAWyo5ilbWr7c7eBpuAULzzd+DV8L8yOEgTA=",
         "scheme": "envelope-large-symmetric-group"
       }
     ]
@@ -34,7 +34,7 @@
         "type": "alert",
         "text": "get ready to scuttle!",
         "recps": [
-          "%b3pHXDR/oPbNK5FI39hQCv9dDaJdV1CZUnYMO5D3/mg=.cloaked"
+          "%Z3w8CD1f+3kndXyVUyDpdr8uHy0XQm5dHEbOBDeRkAw=.cloaked"
         ]
       }
     ]

--- a/vectors/unbox1.json
+++ b/vectors/unbox1.json
@@ -4,26 +4,26 @@
   "input": {
     "msgs": [
       {
-        "key": "%T5Q4w2/guQORn5Z0OBW+DVErq3YJkh21K9oOBCvwNrs=.sha256",
+        "key": "%iPTskfm08k9sfg/i8aXwXbdefCzBuUeaNey507slX/I=.sha256",
         "value": {
           "previous": null,
           "sequence": 1,
-          "author": "@GDCXk8L74o7RF77JEuhV58EySUInU2oL9X28Ud9fYgA=.ed25519",
-          "timestamp": 1592533020780,
+          "author": "@GU3nw+rEjXOEKEXFxqf1WeVUZX42bHrJRUJfwrhW+bg=.ed25519",
+          "timestamp": 1592534932480,
           "hash": "sha256",
-          "content": "4HViSb9O1mA4dSgoQPgUCsMvy1Br737ylOp83czpPo5kvmZeJg5dp04PTLfw838JS7APGhCcCBefq4iCl56cfuzvDZT8Lsihof/Yl+yVJM6mzf95Hj381oV7B7XWX8eqPYJ4PcB2AU7SHmUkcLNi/NXH/Pxtn18oYrALKsC15BRJNdrwRTK7OZsL1smOaemRr69nKHIab4RauwKFT2S9+AtJa/9j/ixG8ezkqB/iTmMmo4lbsT+1w5tb6rGU3BUOKA==.box2",
-          "signature": "Z7qRTEpyrTAidBzpxGa1h5gFE9bU+FZmezbQBcSPRy/YG1dkHejIZTwbp8mNgksG/ZQ0seKMFzCKbtJxqaCeDA==.sig.ed25519"
+          "content": "PGHe5NpkJJgv71rhqa+tLNGy2K/cvnWpPVFpKJEllWweHfXvq4+rbdwbw3e1ax5RLMP+708zpulqy/Y/TvlYe6D4cT7cqiLhRD8NzdM0W28t9YGNJWbJpjW2NccdSRBPD0ZIuwAkXyshosUrxi8CrbmW+4XfFmGPXu8DzHTqpN+j56kyKFd//SfVd8Dy5GwZLpKZPYf62dpInTQlJkPb6NcJQ3+lUe1hhi97iOtIhsB/8jtOPjF/V6qUXrSu/nCs/g==.box2",
+          "signature": "416FiLEtLG+CvbqE1OlrF9Py18WA/sVMgbN2Od2jRIiReqowzOTEp8wmiN+1wCDx7k+kU+ZRb5/nzaxiwDbKBg==.sig.ed25519"
         },
-        "timestamp": 1592533020780.001
+        "timestamp": 1592534932480.001
       }
     ],
     "trial_keys": [
       {
-        "key": "8daH87AuneYvmZ5OANtkpugscaLO3QpQ8JX+1xpRKaU=",
+        "key": "tXD0fgOUVKj4qnhYdgB/B2wjq/9YM7tBydIBYzY8wl8=",
         "scheme": "envelope-large-symmetric-group"
       },
       {
-        "key": "oaBppadDAWyo5ilbWr7c7eBpuAULzzd+DV8L8yOEgTA=",
+        "key": "Is0U1U121chtepf0QcnF0JREhp9NNUgqsPE/1ODGV4Q=",
         "scheme": "envelope-large-symmetric-group"
       }
     ]
@@ -34,7 +34,7 @@
         "type": "alert",
         "text": "get ready to scuttle!",
         "recps": [
-          "%Z3w8CD1f+3kndXyVUyDpdr8uHy0XQm5dHEbOBDeRkAw=.cloaked"
+          "%VTmwWB0ou53Tj99NPyu2iomZuzhVwp0CIiovdeZCKRg=.cloaked"
         ]
       }
     ]

--- a/vectors/unbox2.json
+++ b/vectors/unbox2.json
@@ -4,41 +4,26 @@
   "input": {
     "msgs": [
       {
-        "key": "%PQaO0cJ9Bx0KNUcIJQu+2TXIlPJ0HcvBcb78VSQjjOw=.sha256",
+        "key": "%2U22iDs59VwSYrACVMhg6ow2c0GS4rSuCtHxJeKQPqE=.sha256",
         "value": {
-          "previous": null,
-          "sequence": 1,
-          "author": "@exCiEeSxG6DHE8+qk/TXrWRsd9UT/q2YmIlWsfxAChE=.ed25519",
-          "timestamp": 1583367070444,
-          "hash": "sha256",
-          "content": {
-            "type": "first"
-          },
-          "signature": "oWTfiy25TBGjn4WfadUy9wuAP8oYyJFKlyASGAmRTv3E7EN9HG77sqsTqqSP9B9s3eRToQ6jtrkQ6gFWaB6VCg==.sig.ed25519"
-        },
-        "timestamp": 1583367070445
-      },
-      {
-        "key": "%zeR3/z7aDTVoHG5JSHFJdbZLcSRkuXGXMmCYnnKYeWk=.sha256",
-        "value": {
-          "previous": "%PQaO0cJ9Bx0KNUcIJQu+2TXIlPJ0HcvBcb78VSQjjOw=.sha256",
+          "previous": "%vAOmMW4VqjEWH1ujrl2zrzDT52GUH+Z++7zHZOKQEH0=.sha256",
           "sequence": 2,
-          "author": "@exCiEeSxG6DHE8+qk/TXrWRsd9UT/q2YmIlWsfxAChE=.ed25519",
-          "timestamp": 1583367070561,
+          "author": "@fQWA8NFYWNDD+47ZI9iEu+kvoxlVGm/UGbkXeQ112J0=.ed25519",
+          "timestamp": 1592533020892,
           "hash": "sha256",
-          "content": "oqpBSff3KMkbxB14ixNSt8923PO7EaGanVroQj1dODYHjzTCHwqXG1WBuCn4Bl1rMiUk1ze3E3O1J6RDgiS4CTaUPfrJOhcJ6yfta4Y3tBJUpvMDEewIWKqDz3YnPe2JC9Sx9C0qMOS88OP8l2vHaY5wuuBn/32qtT5RnaHflDZoabvNk2JMct6cFEksqupFQpCGS5jy+ZCIaieugcdBugWBCULuk8yHo8jXZEOr/OcrCG+Qr5wad/RXv/kVdPcqzg==.box2",
-          "signature": "2pKe5DJxE0CUTCR1OIIKofWiPDoPcwYXU8y1r/2DMxwELDwaC7gkc7iBDy4PlLLvHbOATbJ1JR5AyO7W7JGGAA==.sig.ed25519"
+          "content": "c3avibFg3Pp/KIA1cFKimcx5xKIvTulZG1XL9Lvz35ZuzJYsiDRYDnYM0MTBc9pXfXkKtJudDmyW1hbjphAfSxMhqpye/I+mRZOkDYH2kkdYe7Ag6sy6S+Yw44iGUEv58pXXxaf4pZdj4fAw3wqstXEFLSjBvyMsbTxVxXxPxUYE3d+zdpSKEsVs1dZxszPHnCXKi48ecypB//9H7yO6IeXKtsasRnDFSmUCNJSyj5Ptt/LQtsY4vUHBzb3/s5f6JQ==.box2",
+          "signature": "dgquDKiFuPnSonCYqE+li6tYOK6s4hEMIZR2/KDxMbWMpc2HLR9PJqhLeepq9I7v8o7RGpvuuHwkyvK+aDN4Dw==.sig.ed25519"
         },
-        "timestamp": 1583367070562
+        "timestamp": 1592533020893
       }
     ],
     "trial_keys": [
       {
-        "key": "T4XPzJH5ubycPqQIdsXK2u5UHP5lFz+qSAvpYvhgCYg=",
+        "key": "BuT2MHC3AM4BTWj3CzqoWN8SIOi+9Uz8lLdnJLtClEo=",
         "scheme": "envelope-large-symmetric-group"
       },
       {
-        "key": "bHW1dDEMdqjQO+Wl/8YXrUF1XXvYRZLhGs8tdkmwjtk=",
+        "key": "dU78d0MYMunImqh1+duYpSVCeSN4iZW3gVIvdqHmWWE=",
         "scheme": "envelope-large-symmetric-group"
       }
     ]
@@ -52,7 +37,7 @@
         "type": "alert",
         "text": "get ready to scuttle!",
         "recps": [
-          "%mJauGTkp/IkGMBS4s+N2A4/ihF10sq8QIGcKYYSbDcw=.cloaked"
+          "%sVc1xSOLz//xF0MOiwOmuwuJBV2A83pVkob94vUBR8Y=.cloaked"
         ]
       }
     ]

--- a/vectors/unbox2.json
+++ b/vectors/unbox2.json
@@ -4,26 +4,26 @@
   "input": {
     "msgs": [
       {
-        "key": "%2U22iDs59VwSYrACVMhg6ow2c0GS4rSuCtHxJeKQPqE=.sha256",
+        "key": "%1Splppmh9AyVZiKnqXcpYKEic5n1dEMZ90c80QQbjxg=.sha256",
         "value": {
-          "previous": "%vAOmMW4VqjEWH1ujrl2zrzDT52GUH+Z++7zHZOKQEH0=.sha256",
+          "previous": "%735w71E4jLhYLDcdM3zRBDbeOVXm9p+Q54napNZP518=.sha256",
           "sequence": 2,
-          "author": "@fQWA8NFYWNDD+47ZI9iEu+kvoxlVGm/UGbkXeQ112J0=.ed25519",
-          "timestamp": 1592533020892,
+          "author": "@4IXio7MZcoBl4LGlAa894kCvFAvpqOEUPwPOiLbuagY=.ed25519",
+          "timestamp": 1592534932594,
           "hash": "sha256",
-          "content": "c3avibFg3Pp/KIA1cFKimcx5xKIvTulZG1XL9Lvz35ZuzJYsiDRYDnYM0MTBc9pXfXkKtJudDmyW1hbjphAfSxMhqpye/I+mRZOkDYH2kkdYe7Ag6sy6S+Yw44iGUEv58pXXxaf4pZdj4fAw3wqstXEFLSjBvyMsbTxVxXxPxUYE3d+zdpSKEsVs1dZxszPHnCXKi48ecypB//9H7yO6IeXKtsasRnDFSmUCNJSyj5Ptt/LQtsY4vUHBzb3/s5f6JQ==.box2",
-          "signature": "dgquDKiFuPnSonCYqE+li6tYOK6s4hEMIZR2/KDxMbWMpc2HLR9PJqhLeepq9I7v8o7RGpvuuHwkyvK+aDN4Dw==.sig.ed25519"
+          "content": "nRNJ2jLRoHItfcNrWsHgY6KqX3UxW9atpjua36UINPjVMj3drgR/nEYyZbSACg5YzLUTU9xX2o+CWmTnQL4AgYI6GnxwT87pBXr/hMFtEZ3PvTvZR2VJPDGnHeCNjvZ7nRJkfFxB8XlSy0KmTGyU2+TnprHOWYgRkLA4RwwS3lvIqyuyVfU3EhEbtRCD84xBrNORznXzrugywVNyF9h3EterDjdvHsHt64MTWZxqPZdD0atxJRfIkLwJDe9JK8WlQQ==.box2",
+          "signature": "wfcsLX59vmELQfYybdtHZjVtvas4X9ffC1Xa95/vL8ax9xgnIgwjh4EA2Tg1rk3CEmh8iTNPyN3R5PBlVCx5AA==.sig.ed25519"
         },
-        "timestamp": 1592533020893
+        "timestamp": 1592534932594.001
       }
     ],
     "trial_keys": [
       {
-        "key": "BuT2MHC3AM4BTWj3CzqoWN8SIOi+9Uz8lLdnJLtClEo=",
+        "key": "SAoMdSI7THVRSr+dPzYdgMIM5f1NFcpqdtn741hHOq0=",
         "scheme": "envelope-large-symmetric-group"
       },
       {
-        "key": "dU78d0MYMunImqh1+duYpSVCeSN4iZW3gVIvdqHmWWE=",
+        "key": "A7lRB1lxh+vz+FIwDfl+GbtztIM3z0xbiYz7anCp4o8=",
         "scheme": "envelope-large-symmetric-group"
       }
     ]
@@ -31,13 +31,10 @@
   "output": {
     "msgsContent": [
       {
-        "type": "first"
-      },
-      {
         "type": "alert",
         "text": "get ready to scuttle!",
         "recps": [
-          "%sVc1xSOLz//xF0MOiwOmuwuJBV2A83pVkob94vUBR8Y=.cloaked"
+          "%93kpQXoHNYFeCP5OzDIHVTCCK8qJzCl+m08zHlN14oU=.cloaked"
         ]
       }
     ]


### PR DESCRIPTION
This PR : 
- adds `recps` / `key_slot` restriction notes
- changes the `direct-message-key1.json` vector to use TFK encoded dh-keys
- prunes `unbox2.json` vector of an un-needed plaintext msg