### PR TITLE
add "key-for-self" scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,9 @@ In envelope, we instead take "ids" from `content.recps`, and map each to a pair 
 Type of id            | How `key` is found                                 | `scheme`
 ----------------------|----------------------------------------------------|-----------------------------------------
 private group id      | [a key-store](./group/group-id/README.md)          | "envelope-large-symmetric-group"
-classic feedId        | [diff-hellman styles](./direct-messages/README.md) | "envelope-id-based-dm-converted-ed25519"
-published private key | TODO                                               | ???
+another feedId        | [diff-hellman styles](./direct-messages/README.md) | "envelope-id-based-dm-converted-ed25519"
+your feedId           | [locally stored key](./direct-messages/README.md)  | "envelope-symmetric-key-for-self"
+published public key  | TODO                                               | ???
 
 see `key-schemes.json` for the canonical list of accepted schema labels
 

--- a/key-schemes.json
+++ b/key-schemes.json
@@ -2,7 +2,8 @@
   "description": "maps short-names to specific canonical labels for key management schemes",
   "scheme": {
     "private_group": "envelope-large-symmetric-group",
-    "feed_id_dm":    "envelope-id-based-dm-converted-ed25519"
+    "feed_id_dm":    "envelope-id-based-dm-converted-ed25519",
+    "feed_id_self":  "envelope-symmetric-key-for-self"
   }
 }
 


### PR DESCRIPTION
This is a scheme discussed with Keks for how to send DMs which you know how to read.

**Problem**: ideally want to have recps like `[ @mix , @keks , @cryptix ]`

For mapping those ids to keys for enveloping, we have a dh based scheme for foreign keys, but had previously blocked doing the same for our own keys asserting that "you should just use a personal group if you want to send to yourself". This has problems though, as it would leak tangles data about your personal group to keks + cryptex (as we don't currently cloak tangle data).

**Solution** : add a new scheme which is just a key you hold locally for messages encrypted to self. See READMEs for more detail