### PR TITLE
Bug po box vector

### DIFF
--- a/test.js
+++ b/test.js
@@ -1,6 +1,13 @@
 const fs = require('fs')
 const path = require('path')
 
+const TF = {
+  encryptionKeys: {
+    dm: Buffer.from([3, 0]), //   box2-dm-dh
+    poBox: Buffer.from([3, 1]) // box2-poBox-dh
+  }
+}
+
 print(underline('Test vectors'))
 newline()
 fs.readdir(path.join(__dirname, 'vectors'), (_, fileNames) => {
@@ -12,6 +19,19 @@ fs.readdir(path.join(__dirname, 'vectors'), (_, fileNames) => {
       isTrue(isString(vector.type), 'type')
       isTrue(isString(vector.description), 'description')
       isTrue(isObject(vector.input), 'input')
+
+      for (const key in vector.input) {
+        if (
+          key === 'my_dh_secret' ||
+          key === 'my_dh_public' ||
+          key === 'your_dh_public'
+        ) isTrue(isTypeFormat(vector.input[key], TF.encryptionKeys.dm), key + ' is dm key')
+
+        if (
+          key === 'po_box_dh_public'
+        ) isTrue(isTypeFormat(vector.input[key], TF.encryptionKeys.poBox), key + ' is poBox key')
+      }
+
       isTrue(isObject(vector.output), 'output')
     } catch (err) {
       print(red('! is not valid JSON'), 4)
@@ -30,6 +50,10 @@ function isString (s) { return typeof s === 'string' && s.length > 0 }
 function isObject (o) {
   return typeof o === 'object' && o !== null && !Array.isArray(o) &&
     Object.keys(o).length > 0
+}
+function isTypeFormat (str, typeFormatBuffer) {
+  return Buffer.from(str, 'base64').slice(0, 2)
+    .equals(typeFormatBuffer)
 }
 function isTrue (bool, msg = '') {
   bool

--- a/test.js
+++ b/test.js
@@ -26,8 +26,7 @@ fs.readdir(path.join(__dirname, 'vectors'), (_, fileNames) => {
           key === 'my_dh_public' ||
           key === 'your_dh_public'
         ) isTrue(isTypeFormat(vector.input[key], TF.encryptionKeys.dm), key + ' is dm key')
-
-        if (
+        else if (
           key === 'po_box_dh_public'
         ) isTrue(isTypeFormat(vector.input[key], TF.encryptionKeys.poBox), key + ' is poBox key')
       }

--- a/vectors/po-box-key1.json
+++ b/vectors/po-box-key1.json
@@ -5,11 +5,11 @@
     "my_dh_secret": "AwBg/xkWz7qNmtIz0jBWVgiFQoHIFqbJKP9JpYSx1VVbVQ==",
     "my_dh_public": "AwDZg4xIRpi3tbZsfuWVRnbYHNDo33pEBQIiQZaC2TZuPg==",
     "my_feed_id": "AADXDOY5Isl/kWTPOYAryv6lTcDlCQnHb8a35mDCCSILSQ==",
-    "po_box_dh_public": "AwAIFlU+iztEMB7eLSP6fZtpqdt5DFemgSmvqaGbx8I4ZQ==",
+    "po_box_dh_public": "AwEIFlU+iztEMB7eLSP6fZtpqdt5DFemgSmvqaGbx8I4ZQ==",
     "po_box_id": "BwAIFlU+iztEMB7eLSP6fZtpqdt5DFemgSmvqaGbx8I4ZQ=="
   },
   "output": {
-    "shared_key": "1Tecw3JE+H1ng+HQAwQX2apkNHsfiTlHYdLQJMWXGfY=",
+    "shared_key": "V5fA4gnTm5qaa8FKPJk4SFQbmqVmh9MUKW9B4ZSLrZk=",
     "key_scheme": "ZW52ZWxvcGUtaWQtYmFzZWQtcG9ib3gtY3VydmUyNTUxOQ=="
   }
 }


### PR DESCRIPTION
I found a bug!

this test vector for po-box encryption was not a the right BFE type.

What I've done:
- wrote a test to catch incorrect BFE type-format for keys
- fixed the test vector
    - generated the test vector output using `ssb-pirvate-group-keys` module code
  