### PR TITLE
update the spec for group/add-member to be v2!

### DIFF
--- a/generate-schema.js
+++ b/generate-schema.js
@@ -7,7 +7,7 @@ const fs = require('fs')
 
 const types = [
   'group/init',
-  'group/add-member',
+  'group/add-member/v2',
   'group/content'
 ]
 

--- a/group/add-member/README.md
+++ b/group/add-member/README.md
@@ -8,8 +8,9 @@ This is about adding people to your group
 var content = {
   type: "group/add-member",
   version: "v2",
-  root: "ssb:message/classic/THxjTGPuXvvxnbnAV7xVuVXdhDcmoNtDDN0j3UTxcd8=",
   secret: "3YUat1ylIUVGaCjotAvof09DhyFxE8iGbF6QxLlCWWc=",
+  root: "ssb:message/classic/THxjTGPuXvvxnbnAV7xVuVXdhDcmoNtDDN0j3UTxcd8=",
+  creator: "ssb:feed/bendybutt-v1/VuVXdhDTHxjTGPuXvvxnbnAV7xcmoNtDDN0j3UTxcd8=",
   text: "welcome keks!", // optional
   recps: [
     "ssb:identity/group/vof09Dhy3YUat1ylIUVGaCjotAFxE8iGbF6QxLlCWWc=", // group_id
@@ -36,16 +37,19 @@ var content = {
 
 Notes:
 
+- `secret` is the symmetric key for the group
 - `root` is the same as `tangles.group.root`
   - the redundancy is here to make it more obvious which root you should be using the compute `group_id`
   - in the future our tangles may be _cloaked_ which means this key would become more important
+- `creator` is the root metafeed id of the creator of the group
+  - this is needed in case you don't already follow / replicate this person
 - `recps` must include the `group_id` and a `feed_id` (one or more)
   - this ensures that everyone has the same info about who's been added
   - if including multiple, keep in mind `max_attempts` of your application
 - all messages in the group are part of that groups tangle (see `tangles.group`)
   - this makes it possible to query things based on group (e.g. was this in my europe or pacifica group?)
   - provides partial ordering for all activity in the group
-- all `entrust` type messages are part of the membership tangle (see `tangles.members`)
+- all `group/add-member` type messages are part of the membership tangle (see `tangles.members`)
   - this makes it easy to build a history of additions to the group
 - the `tangles.group.root` and `tangles.members.root` are the same
   - this isn't true of all tangles

--- a/group/add-member/README.md
+++ b/group/add-member/README.md
@@ -8,8 +8,8 @@ This is about adding people to your group
 var content = {
   type: "group/add-member",
   version: "v2",
-  groupKey: "3YUat1ylIUVGaCjotAvof09DhyFxE8iGbF6QxLlCWWc=",
   root: "ssb:message/classic/THxjTGPuXvvxnbnAV7xVuVXdhDcmoNtDDN0j3UTxcd8=",
+  secret: "3YUat1ylIUVGaCjotAvof09DhyFxE8iGbF6QxLlCWWc=",
   text: "welcome keks!", // optional
   recps: [
     "ssb:identity/group/vof09Dhy3YUat1ylIUVGaCjotAFxE8iGbF6QxLlCWWc=", // group_id

--- a/group/add-member/README.md
+++ b/group/add-member/README.md
@@ -8,7 +8,7 @@ This is about adding people to your group
 var content = {
   type: "group/add-member",
   version: "v2",
-  secret: "3YUat1ylIUVGaCjotAvof09DhyFxE8iGbF6QxLlCWWc=",
+  groupKey: "3YUat1ylIUVGaCjotAvof09DhyFxE8iGbF6QxLlCWWc=",
   root: "ssb:message/classic/THxjTGPuXvvxnbnAV7xVuVXdhDcmoNtDDN0j3UTxcd8=",
   creator: "ssb:feed/bendybutt-v1/VuVXdhDTHxjTGPuXvvxnbnAV7xcmoNtDDN0j3UTxcd8=",
   text: "welcome keks!", // optional
@@ -37,7 +37,7 @@ var content = {
 
 Notes:
 
-- `secret` is the symmetric key for the group
+- `groupKey` is the symmetric key for the group
 - `root` is the same as `tangles.group.root`
   - the redundancy is here to make it more obvious which root you should be using the compute `group_id`
   - in the future our tangles may be _cloaked_ which means this key would become more important

--- a/group/add-member/README.md
+++ b/group/add-member/README.md
@@ -13,7 +13,7 @@ var content = {
   text: "welcome keks!", // optional
   recps: [
     "ssb:identity/group/vof09Dhy3YUat1ylIUVGaCjotAFxE8iGbF6QxLlCWWc=", // group_id
-    "ssb:feed/classic/YXkE3TikkY4GFMX3lzXUllRkNTbj5E-604AkaO1xbz8=", // feed_id (for new person)
+    "ssb:feed/bendybutt-v1/YXkE3TikkY4GFMX3lzXUllRkNTbj5E-604AkaO1xbz8=", // feed_id (for new person)
   ],
 
   tangles: {

--- a/group/add-member/README.md
+++ b/group/add-member/README.md
@@ -7,7 +7,7 @@ This is about adding people to your group
 ```js
 var content = {
   type: "group/add-member",
-  version: "v1",
+  version: "v2",
   groupKey: "3YUat1ylIUVGaCjotAvof09DhyFxE8iGbF6QxLlCWWc=",
   root: "ssb:message/classic/THxjTGPuXvvxnbnAV7xVuVXdhDcmoNtDDN0j3UTxcd8=",
   text: "welcome keks!", // optional

--- a/group/add-member/v1/schema.json
+++ b/group/add-member/v1/schema.json
@@ -1,0 +1,89 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
+  "required": [
+    "type",
+    "version",
+    "groupKey",
+    "root",
+    "tangles"
+  ],
+  "properties": {
+    "type": { "type": "string", "pattern": "^group/add-member$" },
+    "version": { "type": "string", "pattern": "^v1$" },
+    "groupKey": { "type": "string", "pattern": "^[a-zA-Z0-9\\/+]{42}[AEIMQUYcgkosw048]=$" },
+    "root": { "$ref": "#/definitions/messageId" },
+    "text": { "type": "string" },
+    "recps": { "type": "array",
+      "items": [
+        { "$ref": "#/definitions/cloakedMessageId" }
+      ],
+      "additionalItems": { "$ref": "#/definitions/feedId" },
+      "minItems": 2,
+      "maxItems": 16
+    },
+    "tangles": {
+      "type": "object",
+      "required": [
+        "group",
+        "members"
+      ],
+      "properties": {
+        "group": { "$ref": "#/definitions/tangle/update" },
+        "members": { "$ref": "#/definitions/tangle/any" }
+      }
+    }
+  },
+  "additionalProperties": false,
+
+  "definitions": {
+    "messageId": {
+      "type": "string",
+      "pattern": "^%[a-zA-Z0-9\\/+]{42}[AEIMQUYcgkosw048]=.sha256$"
+    },
+    "cloakedMessageId": {
+      "type": "string",
+      "pattern": "^%[a-zA-Z0-9\\/+]{42}[AEIMQUYcgkosw048]=.cloaked$"
+    },
+    "feedId": {
+      "type": "string",
+      "pattern": "^@[a-zA-Z0-9\\/+]{42}[AEIMQUYcgkosw048]=.(?:sha256|ed25519)$"
+    },
+    "tangle": {
+      "root": {
+        "type": "object",
+        "required": [
+          "root",
+          "previous"
+        ],
+        "properties": {
+          "root": { "type": "null" },
+          "previous": { "type": "null" }
+        }
+      },
+      "update": {
+        "type": "object",
+        "required": [
+          "root",
+          "previous"
+        ],
+        "properties": {
+          "root": {
+            "$ref": "#/definitions/messageId"
+          },
+          "previous": {
+            "type": "array",
+            "item": { "$ref": "#/definitions/messageId" },
+            "minItems": 1
+          }
+        }
+      },
+      "any": {
+        "oneOf": [
+          { "$ref": "#/definitions/tangle/root" },
+          { "$ref": "#/definitions/tangle/update" }
+        ]
+      }
+    }
+  }
+}

--- a/group/add-member/v2/schema.js
+++ b/group/add-member/v2/schema.js
@@ -7,11 +7,20 @@ const { messageId, feedId, groupId, tangle } = require('../../definitions')
 module.exports = {
   $schema: 'http://json-schema.org/schema#',
   type: 'object',
-  required: ['type', 'version', 'secret', 'root', 'creator', 'recps', 'tangles'],
+  required: ['type', 'version', 'groupKey', 'root', 'creator', 'recps', 'tangles'],
   properties: {
-    type: { type: 'string', pattern: '^group/add-member$' },
-    version: { type: 'string', pattern: '^v2$' },
-    secret: { type: 'string', pattern: '^[a-zA-Z0-9\\/+]{42}[AEIMQUYcgkosw048]=$' },
+    type: {
+      type: 'string',
+      pattern: '^group/add-member$'
+    },
+    version: {
+      type: 'string',
+      pattern: '^v2$'
+    },
+    groupKey: {
+      type: 'string',
+      pattern: '^[a-zA-Z0-9\\/+]{42}[AEIMQUYcgkosw048]=$'
+    },
     root: { $ref: '#/definitions/messageId' },
     creator: { $ref: '#/definitions/feedId' },
     text: { type: 'string' },

--- a/group/add-member/v2/schema.js
+++ b/group/add-member/v2/schema.js
@@ -2,26 +2,18 @@
 //
 // SPDX-License-Identifier: LGPL-3.0-only
 
-const { messageId, feedId, groupId, tangle } = require('../definitions')
+const { messageId, feedId, groupId, tangle } = require('../../definitions')
 
 module.exports = {
   $schema: 'http://json-schema.org/schema#',
   type: 'object',
-  required: ['type', 'version', 'groupKey', 'root', 'recps', 'tangles'],
+  required: ['type', 'version', 'secret', 'root', 'creator', 'recps', 'tangles'],
   properties: {
-    type: {
-      type: 'string',
-      pattern: '^group/add-member$'
-    },
-    version: {
-      type: 'string',
-      pattern: '^v1$'
-    },
-    groupKey: {
-      type: 'string',
-      pattern: '^[a-zA-Z0-9\\/+]{42}[AEIMQUYcgkosw048]=$'
-    },
+    type: { type: 'string', pattern: '^group/add-member$' },
+    version: { type: 'string', pattern: '^v2$' },
+    secret: { type: 'string', pattern: '^[a-zA-Z0-9\\/+]{42}[AEIMQUYcgkosw048]=$' },
     root: { $ref: '#/definitions/messageId' },
+    creator: { $ref: '#/definitions/feedId' },
     text: { type: 'string' },
     recps: {
       type: 'array',
@@ -35,7 +27,7 @@ module.exports = {
       required: ['group', 'members'],
       properties: {
         group: { $ref: '#/definitions/tangle/update' },
-        members: { $ref: '#/definitions/tangle/any' }
+        members: { $ref: '#/definitions/tangle/update' }
       }
     }
   },

--- a/group/add-member/v2/schema.json
+++ b/group/add-member/v2/schema.json
@@ -4,8 +4,9 @@
   "required": [
     "type",
     "version",
-    "groupKey",
+    "secret",
     "root",
+    "creator",
     "recps",
     "tangles"
   ],
@@ -16,14 +17,17 @@
     },
     "version": {
       "type": "string",
-      "pattern": "^v1$"
+      "pattern": "^v2$"
     },
-    "groupKey": {
+    "secret": {
       "type": "string",
       "pattern": "^[a-zA-Z0-9\\/+]{42}[AEIMQUYcgkosw048]=$"
     },
     "root": {
       "$ref": "#/definitions/messageId"
+    },
+    "creator": {
+      "$ref": "#/definitions/feedId"
     },
     "text": {
       "type": "string"
@@ -52,7 +56,7 @@
           "$ref": "#/definitions/tangle/update"
         },
         "members": {
-          "$ref": "#/definitions/tangle/any"
+          "$ref": "#/definitions/tangle/update"
         }
       }
     }
@@ -66,7 +70,7 @@
     },
     "feedId": {
       "type": "string",
-      "pattern": "^ssb:feed/classic/[a-zA-Z0-9_\\-]{42}[AEIMQUYcgkosw048]=$"
+      "pattern": "^ssb:feed/bendybutt-v1/[a-zA-Z0-9_\\-]{42}[AEIMQUYcgkosw048]=$"
     },
     "groupId": {
       "type": "string",

--- a/group/add-member/v2/schema.json
+++ b/group/add-member/v2/schema.json
@@ -4,7 +4,7 @@
   "required": [
     "type",
     "version",
-    "secret",
+    "groupKey",
     "root",
     "creator",
     "recps",
@@ -19,7 +19,7 @@
       "type": "string",
       "pattern": "^v2$"
     },
-    "secret": {
+    "groupKey": {
       "type": "string",
       "pattern": "^[a-zA-Z0-9\\/+]{42}[AEIMQUYcgkosw048]=$"
     },

--- a/group/definitions.js
+++ b/group/definitions.js
@@ -11,7 +11,7 @@ const groupId = {
 
 const feedId = {
   type: 'string',
-  pattern: '^ssb:feed/classic/[a-zA-Z0-9_\\-]{42}[AEIMQUYcgkosw048]=$'
+  pattern: '^ssb:feed/bendybutt-v1/[a-zA-Z0-9_\\-]{42}[AEIMQUYcgkosw048]=$'
 }
 
 const tangle = {

--- a/group/init/README.md
+++ b/group/init/README.md
@@ -36,7 +36,7 @@ Adding people to the group would interfere with the [`add-member` spec](../add-m
 
 ```js
 // assume you already know your feedId + prevMsgId for this feed
-var feedId = 'ssb:feed/classic/-oaWWDs8g73EZFUMfW37R_ULtFEjwKN_DczvdYihjbU='
+var feedId = 'ssb:feed/bendybutt-v1/-oaWWDs8g73EZFUMfW37R_ULtFEjwKN_DczvdYihjbU='
 var prevMsgId = 'ssb:message/classic/Zz-Inkte70Qz1UVKUHIhOgo16Oj_n37PfgmIzLDBgZw=.sha256'
 
 var feed_id = ... BFE binary encoding of feed_id

--- a/index.js
+++ b/index.js
@@ -1,7 +1,8 @@
 const Validator = require('is-my-ssb-valid')
 
 const groupInitSchema = require('./group/init/schema.json')
-const groupAddMemberSchema = require('./group/add-member/schema.json')
+const groupAddMemberSchema = require('./group/add-member/v2/schema.json')
+// NOTE group/add-member at v2 (for v1 see ./group/add-member/v1/schema.json)
 const groupContentSchema = require('./group/content/schema.json')
 
 module.exports = {

--- a/test/add-member.test.js
+++ b/test/add-member.test.js
@@ -8,11 +8,14 @@ const isValid = require('../').validator.group.addMember
 const { GroupId, FeedId, MsgId } = require('./helpers')
 
 const Mock = (overwrite = {}) => {
+  const groupRoot = MsgId()
+
   const base = {
     type: 'group/add-member',
-    version: 'v1',
-    groupKey: new SecretKey().toString(),
-    root: MsgId(),
+    version: 'v2',
+    secret: new SecretKey().toString(),
+    root: groupRoot,
+    creator: FeedId(),
     text: 'welcome keks!', // optional
     recps: [
       GroupId()
@@ -21,11 +24,11 @@ const Mock = (overwrite = {}) => {
 
     tangles: {
       group: {
-        root: MsgId(),
+        root: groupRoot,
         previous: [MsgId()]
       },
       members: {
-        root: MsgId(),
+        root: groupRoot,
         previous: [MsgId(), MsgId()]
       }
     }

--- a/test/add-member.test.js
+++ b/test/add-member.test.js
@@ -13,7 +13,7 @@ const Mock = (overwrite = {}) => {
   const base = {
     type: 'group/add-member',
     version: 'v2',
-    secret: new SecretKey().toString(),
+    groupKey: new SecretKey().toString(),
     root: groupRoot,
     creator: FeedId(),
     text: 'welcome keks!', // optional

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -8,7 +8,7 @@ const key = () =>
     .replace(/\+/g, '-')
 
 const GroupId = () => `ssb:identity/group/${key()}`
-const FeedId = () => `ssb:feed/classic/${key()}`
+const FeedId = () => `ssb:feed/bendybutt-v1/${key()}`
 const MsgId = () => `ssb:message/classic/${key()}`
 
 module.exports = {


### PR DESCRIPTION
We have a required change to the format of the `group/add-member` message:
- the feedId in recps MUST be the root feed, which is format bendybutt!
- the version needs to be bumped (this is not the v1 schema any more!)

If we're making breaking changes lets change `groupKey` to `secret`

Look at us, version out specs!

:fire: this PR will require us to do some changes to schema in this spec. Will wait for other PRs to settle down. We may also need to keep both version of the spec, i.e. v1 and v2, as if there are json files being pulled in by Ahau for migration